### PR TITLE
Allow user to enable .htaccess files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update && \
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf && \
     sed -i "s/variables_order.*/variables_order = \"EGPCS\"/g" /etc/php5/apache2/php.ini
 
+ENV ALLOW_OVERRIDE **False**
+
 # Add image configuration and scripts
 ADD run.sh /run.sh
 RUN chmod 755 /*.sh

--- a/README.md
+++ b/README.md
@@ -26,10 +26,18 @@ Test your deployment:
 Hello world!
 
 
+Enable .htaccess files
+------------------------------------
+
+If you app uses .htaccess files you need to pass the ALLOW_OVERRIDE environment variable
+
+    docker run -d -p 80:80 -e ALLOW_OVERRIDE=true tutum/apache-php
+
+
 Loading your custom PHP application
 -----------------------------------
 
-This image can be used as a base image for your PHP application. Create a new `Dockerfile` in your 
+This image can be used as a base image for your PHP application. Create a new `Dockerfile` in your
 PHP application folder with the following contents:
 
     FROM tutum/apache-php

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 chown www-data:www-data /app -R
+
+if [ "$ALLOW_OVERRIDE" = "**False**" ]; then
+    unset ALLOW_OVERRIDE
+else
+    sed -i "s/AllowOverride None/AllowOverride All/g" /etc/apache2/apache2.conf
+fi
+
 source /etc/apache2/envvars
 tail -F /var/log/apache2/* &
 exec apache2 -D FOREGROUND


### PR DESCRIPTION
By setting the ALLOW_OVERRIDE environment variable users can enable the
use of .htaccess files.

Hopefully this propagates to the wordpress stack for tutum.