### PR TITLE
Add pid killer in order to prevent failure on starting container after b…

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -10,4 +10,8 @@ fi
 
 source /etc/apache2/envvars
 tail -F /var/log/apache2/* &
+
+#Apache gets grumpy about PID files pre-existing
+rm -f /var/run/apache2/apache2.pid
+
 exec apache2 -D FOREGROUND


### PR DESCRIPTION
There is an issue "Old PID not allow container to restart " (https://github.com/docker-library/php/issues/53) that was fixed here https://github.com/openbouquet/bouquet-docker/commit/2fc37fc5ab17809abd08ac00ad42b7cb231a9b1e. I just added the same line in the run.sh to prevent the problem from occurring.
